### PR TITLE
Ehub 250 - Visual issue when clicking on a PBC further down the page

### DIFF
--- a/application/ui/widgets/eh-widgets-dir/eh-widgets/src/helpers/scrollToTop.js
+++ b/application/ui/widgets/eh-widgets-dir/eh-widgets/src/helpers/scrollToTop.js
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+const ScrollToTop = (props) => {
+    const location = useLocation();
+    console.log(location)
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [location]);
+
+    return <>{props.children}</>
+};
+
+export default ScrollToTop;

--- a/application/ui/widgets/eh-widgets-dir/eh-widgets/src/helpers/scrollToTop.js
+++ b/application/ui/widgets/eh-widgets-dir/eh-widgets/src/helpers/scrollToTop.js
@@ -1,14 +1,13 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 
 const ScrollToTop = (props) => {
     const location = useLocation();
-    console.log(location)
     useEffect(() => {
         window.scrollTo(0, 0);
     }, [location]);
 
-    return <>{props.children}</>
+    return <>{props.children}</>;
 };
 
 export default ScrollToTop;

--- a/application/ui/widgets/eh-widgets-dir/eh-widgets/src/page/catalog/CatalogPage.js
+++ b/application/ui/widgets/eh-widgets-dir/eh-widgets/src/page/catalog/CatalogPage.js
@@ -11,6 +11,7 @@ import BundleGroupStatusFilter from "./bundle-group-status-filter/BundleGroupSta
 import { getPortalUserByUsername } from "../../integration/Integration";
 import './catalogPage.scss';
 import { SHOW_NAVBAR_ON_MOUNTED_PAGE, BUNDLE_STATUS } from "../../helpers/constants";
+import ScrollToTop from "../../helpers/scrollToTop";
 
 /*
 This is the HUB landing page
@@ -148,6 +149,7 @@ const CatalogPage = ({versionSearchTerm, setVersionSearchTerm}) => {
 
   return (
     <>
+      <ScrollToTop>
         <Content className="CatalogPage">
           <div className="CatalogPage-wrapper">
             <div className="bx--grid bx--grid--full-width catalog-page">
@@ -205,6 +207,7 @@ const CatalogPage = ({versionSearchTerm, setVersionSearchTerm}) => {
             </div>
           </div>
         </Content>
+      </ScrollToTop>
     </>
   );
 };


### PR DESCRIPTION
Hello @nshaw , 

The common react behaviour is to store the last location in react-router history.push(). I have created a wrapper class for scrolling to top as the component loads each time. This wrapper contains a useeffect to ensure that everytime it loads the component as the page loads it runs the scrolltop function. 

This has been tested in local environment (Running react app) to work but before moving to production I would like to test it on testing development environment where we can test the functionality with the Entando server with the react micro-frontend deployed. 