### PR TITLE
ENDOC-694 Update README.md to include history

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Check PR name
         uses: Slashgear/action-check-pr-title@v4.3.0
         with:
-          regexp: "(^EHUB-[0-9]{3,5} .*$|^ENGPM-[0-9]{3,5} .*$)"
-          helpMessage: "Example: 'EHUB-123 A change' or 'ENGPM-123 A change'"
+          regexp: "(^EHUB-[0-9]{3,5} .*$|^ENGPM-[0-9]{3,5} .*$|^ENDOC-[0-9]{3,5} .*$)"
+          helpMessage: "Example: 'EHUB-123 A change' or 'ENGPM-123 A change' or 'ENDOC-123 A change'"
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -80,8 +80,8 @@ jobs:
       - name: Check PR name
         uses: Slashgear/action-check-pr-title@v4.3.0
         with:
-          regexp: "(^EHUB-[0-9]{3,5} .*$|^ENGPM-[0-9]{3,5} .*$)"
-          helpMessage: "Example: 'EHUB-123 A change' or 'ENGPM-123 A change'"
+          regexp: "(^EHUB-[0-9]{3,5} .*$|^ENGPM-[0-9]{3,5} .*$|^ENDOC-[0-9]{3,5} .*$)"
+          helpMessage: "Example: 'EHUB-123 A change' or 'ENGPM-123 A change' or 'ENDOC-123 A change'"
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -61,3 +61,10 @@ Set up permissions to configure the service:
 * Choose `realm-admin` from `Available Roles`. Click `Add selected`. It should appear as an `Assigned Role`.
 
 Note: `BUNDLE-ID` and `PLUGIN-ID` are dynamic values that depend on the publishing url.
+
+
+## History
+* v3.1 Introduces the ability to [support private catalogs](https://developer.entando.com/v7.2/tutorials/solution/entando-hub.html#create-a-private-catalog) and converts the Hub codebase to the newer docker-based (v5) format. Entando 7.2 is required to make use of Hub private catalogs from within the AppBuilder
+  * Note: the git-based bundles (https://github.com/entando-samples/entando-hub-application-bundle.git and https://github.com/entando-samples/entando-hub-content-bundle.git) are now no longer maintained but still available for older Entando versions.
+* v2.1 Includes a number of new features including the ability to add the source URL for each bundle, added support for Docker bundle URLs (new in Entando 7.1), an expanded description field, and a number of usability and security fixes. 
+* v1.x Can be installed in Entando 6.3.2 or higher and includes API-level integration with the Entando 7.0+ App Builder. See https://developer.entando.com/v7.1/tutorials/solution/entando-hub.html for detailed instructions on installing and using the Hub, including connecting an Entando App Builder to any Hub instance.


### PR DESCRIPTION
I've added a history section here so we can publish Hub 3.1 on hub.entando.com and point here for history details. This should let us work with a single Hub entry in the public cloud hub.